### PR TITLE
Submodule tests/integration not available publicly.

### DIFF
--- a/vp/CMakeLists.txt
+++ b/vp/CMakeLists.txt
@@ -36,15 +36,9 @@ subdirs(src)
 enable_testing()
 list(APPEND CMAKE_CTEST_ARGUMENTS "--verbose")
 
-add_test(NAME gdb
-	COMMAND ./test.sh
-	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/gdb")
-add_test(NAME integration
-	COMMAND ./test.sh
-	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/integration")
 add_test(NAME sw
 	COMMAND ./test.sh
 	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/../sw")
 
-set_tests_properties(gdb integration sw PROPERTIES ENVIRONMENT
+set_tests_properties(sw PROPERTIES ENVIRONMENT
 	PATH=$ENV{PATH}:${CMAKE_RUNTIME_OUTPUT_DIRECTORY})


### PR DESCRIPTION
Unfortunately the tests are only available on gitlab.informatik.uni-bremen.de which seems to be limited to university members. 

Maybe they can be mirrored to GitHub. Until then, I removed the tests from the corresponding CMakeLists.txt.