### PR TITLE
fu540_plic: fixed off-by-one error for interrupt priorities

### DIFF
--- a/vp/src/platform/common/fu540_plic.cpp
+++ b/vp/src/platform/common/fu540_plic.cpp
@@ -188,7 +188,7 @@ unsigned int FU540_PLIC::next_pending_irq(unsigned int hart, PrivilegeLevel lvl,
 		if (!conf->is_enabled(irq, lvl) || !is_pending(irq))
 			continue;
 
-		uint32_t prio = interrupt_priorities[irq];
+		uint32_t prio = interrupt_priorities[irq - 1];
 		if (!ignth && prio < get_threshold(hart, lvl))
 			continue;
 


### PR DESCRIPTION
In next_pending_irq, the interrupt number (interval [1:NUMIRQ]) was used as
index to access the interrupt_priorities array (organized as [0:NUMIRQ-1]).
As a result, next_pending_irq used the wrong priority for a given interrupt.
This fix simply adjusts the index in next_pending_irq.

The problem was discovered while (unsuccessfully) testing slip on linux-vp:
Communication on uart1 never triggered a corresponding interrupt (hwirq 4)
in the Linux kernel.
The reason: When the two uarts are initialized, the Linux kernel enables
hwirq 3 and 4 (uart0 and uart1) by setting the corresponding priorities from
0 to 1. With the off-by-one error it in fact enabled hwirq 2 and 3. This
explains why uart0(console) was still working, while uart1 was not.
With this fix, these issues are resolved and slip networking is working
again.