### PR TITLE
Performance improvements in GDBServer

### DIFF
--- a/vp/src/core/common/gdb-mc/gdb_server.cpp
+++ b/vp/src/core/common/gdb-mc/gdb_server.cpp
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <libgdb/parser2.h>
 #include <libgdb/response.h>
 
@@ -73,6 +74,8 @@ void GDBServer::create_sock(uint16_t port) {
 		throw std::system_error(errno, std::generic_category());
 
 	reuse = 1;
+	if (setsockopt(sockfd, SOL_TCP, TCP_NODELAY, &reuse, sizeof(reuse)) == -1)
+		goto err;
 	if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) == -1)
 		goto err;
 


### PR DESCRIPTION
In GDB protocol we are sending bunch of smaller packets. Without this change I see that all packets arrive at least 40ms apart (tested on workstation-grade system).

Literature: http://www.unixguide.net/network/socketfaq/2.16.shtml