### PR TITLE
cmake: set minimum required version back to 3.18 (support stock debian 11)

### DIFF
--- a/vp/CMakeLists.txt
+++ b/vp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.18)
 project(riscv-vp
 	VERSION 1.2.2
 )

--- a/vp/src/util/gtkwave_riscv-filter/CMakeLists.txt
+++ b/vp/src/util/gtkwave_riscv-filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.18)
 project(GTKWAVE_RISCV_INSTR_FILTER CXX)
 
 SET(INSTR ${CMAKE_CURRENT_SOURCE_DIR}/../../core/common)


### PR DESCRIPTION
Hi,

The latest stable Debian release (11) ships with cmake 3.18. Since there seems to be no strict need to require cmake >= 3.20, and Debian (and derived distributions) are widely used, it would be very convenient for their users to reset the requirement back to 3.18.

best regards,
Manfred